### PR TITLE
Fix std::max compilation error on Windows

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -2753,7 +2753,7 @@ template<typename T = no_user_data> class poller_t
     {
         int rc = zmq_poller_size(const_cast<void *>(poller_ptr.get()));
         ZMQ_ASSERT(rc >= 0);
-        return static_cast<size_t>(std::max(rc, 0));
+        return static_cast<size_t>((std::max)(rc, 0));
     }
 #endif
 


### PR DESCRIPTION
Fixes #654